### PR TITLE
Fix: Usa set com merge:true para atualizar perfil do usuário

### DIFF
--- a/js/user/userProfile.js
+++ b/js/user/userProfile.js
@@ -265,7 +265,7 @@ async function saveUserProfile() {
         }
         
         // Atualiza os dados no banco
-        await db.doc(`users/${userId}`).update(updateData);
+        await db.doc(`users/${userId}`).set(updateData, { merge: true });
         
         // Atualiza a interface
         document.getElementById('user-display-name').textContent = newNickname;


### PR DESCRIPTION
Altera a função saveUserProfile para usar db.doc().set({ merge: true }) em vez de db.doc().update() ao salvar as informações do perfil do usuário.

Isso corrige o erro 'No document to update' que ocorria quando o documento do usuário ainda não existia no Firestore, garantindo que o documento seja criado se necessário.